### PR TITLE
fix: removing `md` Vale checks

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -22,7 +22,7 @@ Packages = Google
 # Define the Ansys vocabulary
 Vocab = ANSYS
 
-[*.{md,rst}]
+[*.{rst}]
 
 # Apply the following styles
 BasedOnStyles = Vale, Google

--- a/doc/changelog.d/323.fixed.md
+++ b/doc/changelog.d/323.fixed.md
@@ -1,0 +1,1 @@
+fix: removing `md` Vale checks


### PR DESCRIPTION
Vale is failing because of the Markdown changelog fragment files. Removing checks on Markdown will fix the error. 