### PR TITLE
doc: adding release notes in documentation

### DIFF
--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,7 +1,9 @@
 {% if sections[""] %}
 {% for category, val in definitions.items() if category in sections[""] %}
 
-### {{ definitions[category]['name'] }}
+{{ definitions[category]['name'] }}
+{% set underline = '^' * definitions[category]['name']|length %}
+{{ underline }}
 
 {% for text, values in sections[""][category].items() %}
 - {{ text }} {{ values|join(', ') }}

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,0 +1,10 @@
+.. _ref_release_notes:
+
+Release notes
+=============
+
+This document contains the release notes for the PyAnsys Geometry project.
+
+.. vale off
+
+.. towncrier release notes start

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -96,3 +96,4 @@ For comprehensive PyAnsys Math examples, see :ref:`ref_pymath_examples`.
    api/index
    examples/index
    contributing/index
+   changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,11 @@ quiet-level = 3
 [tool.towncrier]
 package = "ansys.math.core"
 directory = "doc/changelog.d"
-filename = "CHANGELOG.md"
-start_string = "<!-- towncrier release notes start -->\n"
-underlines = ["", "", ""]
+filename = "doc/source/changelog.rst"
 template = "doc/changelog.d/changelog_template.jinja"
-title_format = "## [{version}](https://github.com/ansys/pyansys-math/releases/tag/v{version}) - {project_date}"
-issue_format = "[#{issue}](https://github.com/ansys/pyansys-math/pull/{issue})"
+start_string = ".. towncrier release notes start\n"
+title_format = "`{version} <https://github.com/ansys/pyansys-math/releases/tag/v{version}>`_ - {project_date}"
+issue_format = "`#{issue} <https://github.com/ansys/pyansys-math/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
 directory = "added"


### PR DESCRIPTION
Implementing release note in documentation, using https://github.com/ansys/pyansys-geometry/pull/1138.