### PR TITLE
maint: adding `update-changelog` as a CICD dependency

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -344,7 +344,7 @@ jobs:
   release:
     name: "Release project to public PyPI and GitHub"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs:  [package]
+    needs:  [package, update-changelog]
     runs-on: ubuntu-latest
     steps:
 

--- a/doc/changelog.d/329.changed.md
+++ b/doc/changelog.d/329.changed.md
@@ -1,0 +1,1 @@
+maint: adding `update-changelog` as a CICD dependency


### PR DESCRIPTION
This PR is a duplicate of https://github.com/ansys/pyansys-math/pull/327 as it has been merged in `release/0.1` instead of `main`